### PR TITLE
Ian-imgslider-cleanup

### DIFF
--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -11,9 +11,9 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
 
             //Sets all the values needed for creating the sliders. wid is created to allow model values to be obtained in functions within this render function.
             var wid = this;
-            var img_max = this.model.get("series_max");
-            var vrange_min = this.model.get("img_min");
-            var vrange_max = this.model.get("img_max");
+            var img_max = this.model.get("_series_max");
+            var vrange_min = this.model.get("_img_min");
+            var vrange_max = this.model.get("_img_max");
             var vrange_step = (vrange_max - vrange_min)/100;
             var vrange = [vrange_min, vrange_max];
 
@@ -60,11 +60,11 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 min: 0,
                 max: img_max,
                 /*When the handle slides, this function is called to update hslide_label 
-                  and change img_change_trig on the backend (triggers the update_image function on the backend)*/
+                  and change img_index on the backend (triggers the update_image function on the backend)*/
                 slide: function(event, ui) {
                     hslide_label.val( ui.value );
                     console.log("Executed!");
-                    wid.model.set("img_change_trig", ui.value);
+                    wid.model.set("img_index", ui.value);
                     wid.touch();
                 }
             });
@@ -105,11 +105,11 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 max: vrange_max,
                 values: vrange,
                 step: vrange_step,
-                /*When either handle slides, this function sets img_min and/or img_max on the backend to the handles' values.
+                /*When either handle slides, this function sets _img_min and/or _img_max on the backend to the handles' values.
                   This triggers the update_image function on the backend.*/
                 slide: function(event, ui) {
-                    wid.model.set("img_min", ui.values[0]);
-                    wid.model.set("img_max", ui.values[1]);
+                    wid.model.set("_img_min", ui.values[0]);
+                    wid.model.set("_img_max", ui.values[1]);
                     wid.touch();
                 }
             });
@@ -123,33 +123,33 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             console.log("done with data box");
 
             
-            /*This function sets offsetX and offsetY on the backend to the event-specific offset values whenever
+            /*This function sets _offsetX and _offsetY on the backend to the event-specific offset values whenever
               the mouse moves over the image. It then calculates the data-based XY coordinates and displays them
               in the x_coord and y_coord span fields.*/
             img.mousemove(function(event){
-                wid.model.set("offsetX", event.offsetX);
-                wid.model.set("offsetY", event.offsetY);
+                wid.model.set("_offsetX", event.offsetX);
+                wid.model.set("_offsetY", event.offsetY);
                 wid.touch();
-                x_coord.text(Math.floor(event.offsetX*1./(wid.model.get("width"))*(wid.model.get("ncols"))));
-                y_coord.text(Math.floor(event.offsetY*1./(wid.model.get("height"))*(wid.model.get("nrows"))));
+                x_coord.text(Math.floor(event.offsetX*1./(wid.model.get("width"))*(wid.model.get("_ncols"))));
+                y_coord.text(Math.floor(event.offsetY*1./(wid.model.get("height"))*(wid.model.get("_nrows"))));
             });
 
-            //Triggers on_pixval_change and on_img_change when the backend values of pix_val and _b64value change.
-            this.model.on("change:pix_val", this.on_pixval_change, this);
+            //Triggers on_pixval_change and on_img_change when the backend values of _pix_val and _b64value change.
+            this.model.on("change:_pix_val", this.on_pixval_change, this);
             this.model.on("change:_b64value", this.on_img_change, this);
         },
 
         /*If there is no custom error message, this function sets the value of the img-value span field to
-          the value of pix_val from the backend. Otherwise, it sets the value of this field to the value of
+          the value of _pix_val from the backend. Otherwise, it sets the value of this field to the value of
           err (the error message).*/
 
         on_pixval_change: function() {
             console.log("Executing on_pixval_change");
-            if (this.model.get("err") == "") {
-                this.$el.find(".img-value").text(this.model.get("pix_val"));
+            if (this.model.get("_err") == "") {
+                this.$el.find(".img-value").text(this.model.get("_pix_val"));
             }
             else {
-                this.$el.find(".img-value").text(this.model.get("err"));
+                this.$el.find(".img-value").text(this.model.get("_err"));
             }
         },
 

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -85,8 +85,9 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             
             //Creates the label for the vertical slider with a static value of "Z range" (done in the same way as the other label)
             var vslide_label = $('<input type="text" readonly style="border:0">'); vslide_label.addClass("vslabel");
-            vslide_label.val("\n\nZ range");
-            vslide_label.css("paddingBottom", "10px");
+            vslide_label.val("Z range");
+            vslide_label.css("marginTop", "10px");
+            vslide_label.css("marginBottom", "10px");
             //Creates the vertical slider using JQuery UI
             var vslide_html = $("<div>"); vslide_html.addClass("vslider");
             vslide_html.slider({

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -22,8 +22,17 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
               data_vbox stores the html text element (displays the XY coordinates of the mouse and that position's value) and the vertical (Z range) slider.*/
 
             var widget_area = $("<div>"); widget_area.addClass("flex-container");
+            
+            widget_area.css("display", "-webkit-flex"); widget_area.css("display", "flex");
+            widget_area.css("justifyContent", "flex-start"); widget_area.width(1000); widget_area.height(this.model.get("height") * 1.3);
+            
             var img_vbox = $("<div>"); img_vbox.addClass("flex-item-img img-box");
+
+            img_vbox.width(this.model.get("width") * 1.1); img_vbox.height(this.model.get("height") * 1.25); img_vbox.css("padding", "5px");
+
             var data_vbox = $("<div>"); data_vbox.addClass("flex-item-data data-box");
+
+            data_vbox.width(1000 - this.model.get("width") * 1.1 - 25); data_vbox.height(this.model.get("height") * 1.25); data_vbox.css("padding", "5px");
 
             //Adds the img_vbox and data_vbox to the overall flexbox.
 
@@ -108,6 +117,8 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
 
             
             //Adds vslide_label and vslide_html to data_vbox. At this point, the widget can be successfully displayed.
+            console.log(text_content.outerHeight(true))
+            console.log(vslide_label.outerHeight(true))
             vslide_html.height(this.model.get("height") * 0.75);
             data_vbox.append(vslide_label);
             data_vbox.append(vslide_html);

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -17,20 +17,20 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             var vrange_step = (vrange_max - vrange_min)/100;
             var vrange = [vrange_min, vrange_max];
 
-            /*Creates the flexbox that will store the widget and the two flexitems that it will contain.
+            /*Creates the flexbox that will store the widget and the two flexitems that it will contain. Also formats all of them.
               img_vbox stores the image and the horizontal (Image Selector) slider.
               data_vbox stores the html text element (displays the XY coordinates of the mouse and that position's value) and the vertical (Z range) slider.*/
 
-            var widget_area = $("<div>"); widget_area.addClass("flex-container");
+            var widget_area = $('<div class="flex-container">');
             
             widget_area.css("display", "-webkit-flex"); widget_area.css("display", "flex");
             widget_area.css("justifyContent", "flex-start"); widget_area.width(1000); widget_area.height(this.model.get("height") * 1.3);
             
-            var img_vbox = $("<div>"); img_vbox.addClass("flex-item-img img-box");
+            var img_vbox = $('<div class="flex-item-img img-box">');
 
             img_vbox.width(this.model.get("width") * 1.1); img_vbox.height(this.model.get("height") * 1.25); img_vbox.css("padding", "5px");
 
-            var data_vbox = $("<div>"); data_vbox.addClass("flex-item-data data-box");
+            var data_vbox = $('<div class="flex-item-data data-box">');
 
             data_vbox.width(1000 - this.model.get("width") * 1.1 - 25); data_vbox.height(this.model.get("height") * 1.25); data_vbox.css("padding", "5px");
 
@@ -43,19 +43,18 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             this.$el.append(widget_area);
 
             //Creates the image stored in the initial value of _b64value and adds it to img_vbox.
-            var img = $("<img>");
+            var img = $('<img class="curr-img">');
             var image_src = "data:image/" + this.model.get("_format") + ";base64," + this.model.get("_b64value")
             img.attr("src", image_src);
-            img.addClass("curr-img");
+            
             img.css("margin", "10px");
             img.width(this.model.get("width")); img.height(this.model.get("height"));
             img_vbox.append(img);
 
             //Creates a read-only input field with no border to dynamically display the value of the horizontal slider.
-            var hslide_label = $('<input type="text" readonly style="border:0">'); 
-            hslide_label.addClass("hslabel");
+            var hslide_label = $('<input class="hslabel" type="text" readonly style="border:0">'); 
             //Creates the horizontal slider using JQuery UI
-            var hslide_html = $('<div>'); hslide_html.addClass("hslider");
+            var hslide_html = $('<div class="hslider">');
             hslide_html.slider({
                 value: 0,
                 min: 0,
@@ -80,25 +79,25 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             console.log("done with img box");
 
             //Creates the fields (divs and spans) for the current mouse position and that position's value and adds them to data_vbox.
-            var text_content = $("<div>"); text_content.addClass("widget-html-content");
+            var text_content = $('<div class="widget-html-content">');
             var xy = $("<div>"); xy.text("X,Y: ");
-            var x_coord = $("<span>"); x_coord.addClass("img-offsetx");
-            var y_coord = $("<span>"); y_coord.addClass("img-offsety");
+            var x_coord = $('<span class="img-offsetx">');
+            var y_coord = $('<span class="img-offsety">');
             xy.append(x_coord); xy.append(", "); xy.append(y_coord);
             var value = $("<div>"); value.text("Value: ");
-            var val = $("<span>"); val.addClass("img-value");
+            var val = $('<span class="img-value">');
             value.append(val);
             text_content.append(xy); text_content.append(value);
             data_vbox.append(text_content);
             console.log(data_vbox);
             
             //Creates the label for the vertical slider with a static value of "Z range" (done in the same way as the other label)
-            var vslide_label = $('<input type="text" readonly style="border:0">'); vslide_label.addClass("vslabel");
+            var vslide_label = $('<input class="vslabel" type="text" readonly style="border:0">');
             vslide_label.val("Z range");
             vslide_label.css("marginTop", "10px");
             vslide_label.css("marginBottom", "10px");
             //Creates the vertical slider using JQuery UI
-            var vslide_html = $("<div>"); vslide_html.addClass("vslider");
+            var vslide_html = $('<div class="vslider">');
             vslide_html.slider({
                 range: true,
                 orientation: "vertical",

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -44,7 +44,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
 
             //Creates a read-only input field with no border to dynamically display the value of the horizontal slider.
             var hslide_label = $('<input type="text" readonly style="border:0">'); 
-            hslide_label.attr("id", "hslabel");
+            hslide_label.addClass("hslabel");
             //Creates the horizontal slider using JQuery UI
             var hslide_html = $('<div>'); hslide_html.addClass("hslider");
             hslide_html.slider({
@@ -84,7 +84,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             console.log(data_vbox);
             
             //Creates the label for the vertical slider with a static value of "Z range" (done in the same way as the other label)
-            var vslide_label = $('<input type="text" readonly style="border:0">'); vslide_label.attr("id", "vs-label");
+            var vslide_label = $('<input type="text" readonly style="border:0">'); vslide_label.addClass("vslabel");
             vslide_label.val("\n\nZ range");
             vslide_label.css("paddingBottom", "10px");
             //Creates the vertical slider using JQuery UI
@@ -140,7 +140,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 this.$el.find(".img-value").text(this.model.get("pix_val"));
             }
             else {
-                this.$el.children(".img-value").text(this.model.get("err"));
+                this.$el.find(".img-value").text(this.model.get("err"));
             }
         },
 

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -117,8 +117,6 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
 
             
             //Adds vslide_label and vslide_html to data_vbox. At this point, the widget can be successfully displayed.
-            console.log(text_content.outerHeight(true))
-            console.log(vslide_label.outerHeight(true))
             vslide_html.height(this.model.get("height") * 0.75);
             data_vbox.append(vslide_label);
             data_vbox.append(vslide_html);

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -50,7 +50,6 @@ class ImageSlider(ipyw.DOMWidget):
         import numpy as np
         self.img_min, self.img_max = int(np.min(arr)), int(np.max(arr))
         self.update_image(None);
-        self.set_css();
         super(ImageSlider, self).__init__()
         return
     
@@ -123,11 +122,11 @@ class ImageSlider(ipyw.DOMWidget):
         self._b64value = self.getimg_bytes()
         return
     
-    def set_css(self):
-        """Creates the CSS classes that are used to format the HTML flexboxes and flexitems used to store the UI on screen.
-        Done on the backend to allow the boxes to be sized according to the width and height values provided in the constructor."""
+    """def set_css(self):
+        #Creates the CSS classes that are used to format the HTML flexboxes and flexitems used to store the UI on screen.
+        #Done on the backend to allow the boxes to be sized according to the width and height values provided in the constructor.
         
-        display(HTML("""
+        display(HTML(#If using, include triple quotes
         <html>
         <body>
         <style type="text/css">
@@ -152,10 +151,10 @@ class ImageSlider(ipyw.DOMWidget):
         }
         </style>
         </body>
-        </html>""" 
+        </html>#If using, include triple quotes
             %(str(self.height * 1.3), str(self.width * 1.1), str(self.height * 1.25), str(1000 - self.width * 1.1 - 25), 
               str(self.height * 1.25))))
-        return
+        return"""
 
 
 def get_js():

--- a/tests/test_image_slider.ipynb
+++ b/tests/test_image_slider.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# cd ~/dv/sje/ipywe/tests"
@@ -79,6 +81,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ipywe.imageslider.ImageSlider(images, 200, 200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -88,9 +99,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python2-cg1d at jnrk-cg1d-analysis2",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "jnrk-cg1d-analysis2-python2-cg1d"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
@@ -102,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Moved the functionality of the set_css function from imageslider.py to imageslider.js. The original set_css function is still present in imageslider.py, but it has been commented out. All other changes are simple refactoring and stylistic changes to clean up the code and make it easier to read.