### PR TITLE
ImageSlider with Zoom and ROI

### DIFF
--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -322,7 +322,6 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                         xcols_right = parseInt(wid.model.get("_extracols") / 2);
                     }
                 }
-                console.log("coords: (" + x_coordinate + ", " + y_coordinate + ")");
                 if (y_coordinate < yrows_top || (y_coordinate > wid.model.get("_nrows_currimg") - yrows_bottom && yrows_bottom != Number.MAX_SAFE_INTEGER) || x_coordinate < xcols_left || (x_coordinate > wid.model.get("_ncols_currimg") - xcols_right && xcols_right != Number.MAX_SAFE_INTEGER)) {
                     x_coord.text("");
                     y_coord.text("");

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -327,8 +327,8 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                     y_coord.text("");
                 }
                 else {
-                    x_coord.text((x_coordinate - xcols_left));
-                    y_coord.text((y_coordinate - yrows_top));
+                    x_coord.text((x_coordinate - xcols_left) + wid.model.get("_xcoord_absolute"));
+                    y_coord.text((y_coordinate - yrows_top) + wid.model.get("_ycoord_absolute"));
                 }
             });
 

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -211,8 +211,8 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                       box.
                     */
                     select.css({
-                        "width": width - 1,
-                        "height": height - 1,
+                        "width": width,
+                        "height": height,
                         "top": new_y,
                         "left": new_x,
                         "background": "transparent",
@@ -377,6 +377,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             this.model.on("change:_pix_val", this.on_pixval_change, this);
             this.model.on("change:_b64value", this.on_img_change, this);
             this.model.on("change:_b64value", this.calc_roi, this);
+            this.model.on("change:_vslide_reset", this.reset_vslide, this);
         },
 
         /*If the text of the coordinate fields (x_coord and y_coord) contain empty strings, the value field will 
@@ -421,6 +422,11 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             var corns = topleft + "  " + topright + "\n        " + bottomleft + "  " + bottomright;
             console.log(corns);
             this.$el.find(".roi").text(corns);
+        },
+
+        reset_vslide: function() {
+            $(".vslider").slider("values", 0, this.model.get("_img_min"));
+            $(".vslider").slider("values", 1, this.model.get("_img_max"));
         }
 	
     });

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -81,6 +81,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             //Sets the label's initial value to the initial value of the slider and adds a left margin to the label
             hslide_label.val(hslide_html.slider("value"));
             hslide_label.css("marginLeft", "7px");
+            hslide_label.width("30%");
             //Makes the slider's handle a blue circle and adds a 10 pixel margin to the slider
             var hslide_handle = hslide_html.find(".ui-slider-handle");
             hslide_handle.css("borderRadius", "50%");

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -49,7 +49,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 position: "relative",
                 width: this.model.get("width"),
                 height: this.model.get("height"),
-                margin: "10px"
+                padding: "10px"
             });
 
             //Creates the image stored in the initial value of _b64value and adds it to img_vbox.
@@ -87,6 +87,8 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             hslide_handle.css("borderRadius", "50%");
             hslide_handle.css("background", "#0099e6");
             hslide_html.css("margin", "10px");
+            hslide_html.css("marginBottom", "5px");
+            hslide_html.css("marginTop", "20px");
             //Adds hslide_html (the slider) and hslide_label (the label) to img_vbox
             img_vbox.append(hslide_html);
             img_vbox.append(hslide_label);
@@ -139,7 +141,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
 
             img.on("dragstart", false);
 
-            img.on("mousedown", function(event) {
+            img_container.on("mousedown", function(event) {
                 console.log("Click 1");
                 var click_x = event.offsetX;
                 var click_y = event.offsetY;
@@ -155,7 +157,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 
                 select.appendTo(img_container);
 
-                img.on("mousemove", function(event) {
+                img_container.on("mousemove", function(event) {
                     console.log("Mouse moving");
                     var move_x = event.offsetX;
                     var move_y = event.offsetY;
@@ -183,7 +185,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
 
                 }).on("mouseup", function(event) {
                     console.log("Click 2");
-                    img.off("mousemove");
+                    img_container.off("mousemove");
                 });
             });
 

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -48,8 +48,8 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             img_container.css({
                 position: "relative",
                 width: this.model.get("width"),
-                height: this.model.get("height"),
-                padding: "10px"
+                height: this.model.get("height")
+                //padding: "10px"
             });
 
             //Creates the image stored in the initial value of _b64value and adds it to img_vbox.
@@ -80,13 +80,13 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             
             //Sets the label's initial value to the initial value of the slider and adds a left margin to the label
             hslide_label.val(hslide_html.slider("value"));
-            hslide_label.css("marginLeft", "7px");
             hslide_label.width("15%");
             //Makes the slider's handle a blue circle and adds a 10 pixel margin to the slider
             var hslide_handle = hslide_html.find(".ui-slider-handle");
             hslide_handle.css("borderRadius", "50%");
             hslide_handle.css("background", "#0099e6");
-            hslide_html.css("margin", "10px");
+            hslide_html.width(this.model.get("width"));
+            hslide_html.css("marginLeft", "7px");
             hslide_html.css("marginBottom", "5px");
             hslide_html.css("marginTop", "20px");
             //Adds hslide_html (the slider) and hslide_label (the label) to img_vbox
@@ -283,7 +283,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             vslide_bar.siblings().css("borderRadius", "50%");
             vslide_bar.siblings().css("background", "#0099e6");
             //Adds vslide_label and vslide_html to data_vbox. At this point, the widget can be successfully displayed.
-            vslide_html.height(this.model.get("height") * 0.75);
+            vslide_html.height(this.model.get("height") * 0.7);
             data_vbox.append(vslide_label);
             data_vbox.append(vslide_html);
             console.log(data_vbox);

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -270,8 +270,67 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 wid.model.set("_offsetX", event.offsetX);
                 wid.model.set("_offsetY", event.offsetY);
                 wid.touch();
-                x_coord.text(Math.floor(event.offsetX*1./(wid.model.get("width"))*(wid.model.get("_ncols"))));
-                y_coord.text(Math.floor(event.offsetY*1./(wid.model.get("height"))*(wid.model.get("_nrows"))));
+                console.log(wid.model.get("_extrarows"), wid.model.get("_extracols"));
+                var yrows_top, yrows_bottom, xcols_left, xcols_right, x_coordinate, y_coordinate;
+                x_coordinate = Math.floor(event.offsetX*1./(wid.model.get("width"))*(wid.model.get("_ncols_currimg")));
+                y_coordinate = Math.floor(event.offsetY*1./(wid.model.get("height"))*(wid.model.get("_nrows_currimg")));
+                if (wid.model.get("_extrarows") == 0 && wid.model.get("_extracols") == 0) {
+                    yrows_top = 0;
+                    yrows_bottom = Number.MAX_SAFE_INTEGER;
+                    xcols_left = 0;
+                    xcols_right = Number.MAX_SAFE_INTEGER;
+                }
+                else if (wid.model.get("_extrarows") != 0 && wid.model.get("_extracols") == 0) {
+                    if (wid.model.get("_extrarows") % 2 == 0) {
+                        yrows_top = wid.model.get("_extrarows") / 2;
+                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                    }
+                    else {
+                        yrows_top = wid.model.get("_extrarows") / 2 + 1;
+                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                    }
+                    xcols_left = 0;
+                    xcols_right = Number.MAX_SAFE_INTEGER;
+                }
+                else if (wid.model.get("_extrarows") == 0 && wid.model.get("_extracols") != 0) {
+                    if (wid.model.get("_extracols") % 2 == 0) {
+                        xcols_left = wid.model.get("_extracols") / 2;
+                        xcols_right = wid.model.get("_extracols") / 2;
+                    }
+                    else {
+                        xcols_left = wid.model.get("_extracols") / 2 + 1;
+                        xcols_right = wid.model.get("_extracols") / 2;
+                    }
+                    yrows_top = 0;
+                    yrows_bottom = Number.MAX_SAFE_INTEGER;
+                }
+                else {
+                    if (wid.model.get("_extrarows") % 2 == 0) {
+                        yrows_top = wid.model.get("_extrarows") / 2;
+                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                    }
+                    else {
+                        yrows_top = wid.model.get("_extrarows") / 2 + 1;
+                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                    }
+                    if (wid.model.get("_extracols") % 2 == 0) {
+                        xcols_left = wid.model.get("_extracols") / 2;
+                        xcols_right = wid.model.get("_extracols") / 2;
+                    }
+                    else {
+                        xcols_left = wid.model.get("_extracols") / 2 + 1;
+                        xcols_right = wid.model.get("_extracols") / 2;
+                    }
+                }
+                console.log("coords: (" + x_coordinate + ", " + y_coordinate + ")");
+                if (y_coordinate < yrows_top || (y_coordinate > wid.model.get("_nrows_currimg") - yrows_bottom && yrows_bottom != Number.MAX_SAFE_INTEGER) || x_coordinate < xcols_left || (x_coordinate > wid.model.get("_ncols_currimg") - xcols_right && xcols_right != Number.MAX_SAFE_INTEGER)) {
+                    x_coord.text("");
+                    y_coord.text("");
+                }
+                else {
+                    x_coord.text((x_coordinate - xcols_left));
+                    y_coord.text((y_coordinate - yrows_top));
+                }
             });
 
             //Triggers on_pixval_change and on_img_change when the backend values of _pix_val and _b64value change.
@@ -285,11 +344,16 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
 
         on_pixval_change: function() {
             console.log("Executing on_pixval_change");
-            if (this.model.get("_err") == "") {
-                this.$el.find(".img-value").text(this.model.get("_pix_val"));
+            if (this.$el.find(".img-offsetx").text() == "" && this.$el.find(".img-offsety").text() == "") {
+                this.$el.find(".img-value").text("");
             }
             else {
-                this.$el.find(".img-value").text(this.model.get("_err"));
+                if (this.model.get("_err") == "") {
+                    this.$el.find(".img-value").text(this.model.get("_pix_val"));
+                }
+                else {
+                    this.$el.find(".img-value").text(this.model.get("_err"));
+                }
             }
         },
 

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -282,44 +282,44 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 }
                 else if (wid.model.get("_extrarows") != 0 && wid.model.get("_extracols") == 0) {
                     if (wid.model.get("_extrarows") % 2 == 0) {
-                        yrows_top = wid.model.get("_extrarows") / 2;
-                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                        yrows_top = parseInt(wid.model.get("_extrarows") / 2);
+                        yrows_bottom = parseInt(wid.model.get("_extrarows") / 2);
                     }
                     else {
-                        yrows_top = wid.model.get("_extrarows") / 2 + 1;
-                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                        yrows_top = parseInt(wid.model.get("_extrarows") / 2 + 1);
+                        yrows_bottom = parseInt(wid.model.get("_extrarows") / 2);
                     }
                     xcols_left = 0;
                     xcols_right = Number.MAX_SAFE_INTEGER;
                 }
                 else if (wid.model.get("_extrarows") == 0 && wid.model.get("_extracols") != 0) {
                     if (wid.model.get("_extracols") % 2 == 0) {
-                        xcols_left = wid.model.get("_extracols") / 2;
-                        xcols_right = wid.model.get("_extracols") / 2;
+                        xcols_left = parseInt(wid.model.get("_extracols") / 2);
+                        xcols_right = parseInt(wid.model.get("_extracols") / 2);
                     }
                     else {
-                        xcols_left = wid.model.get("_extracols") / 2 + 1;
-                        xcols_right = wid.model.get("_extracols") / 2;
+                        xcols_left = parseInt(wid.model.get("_extracols") / 2 + 1);
+                        xcols_right = parseInt(wid.model.get("_extracols") / 2);
                     }
                     yrows_top = 0;
                     yrows_bottom = Number.MAX_SAFE_INTEGER;
                 }
                 else {
                     if (wid.model.get("_extrarows") % 2 == 0) {
-                        yrows_top = wid.model.get("_extrarows") / 2;
-                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                        yrows_top = parseInt(wid.model.get("_extrarows") / 2);
+                        yrows_bottom = parseInt(wid.model.get("_extrarows") / 2);
                     }
                     else {
-                        yrows_top = wid.model.get("_extrarows") / 2 + 1;
-                        yrows_bottom = wid.model.get("_extrarows") / 2;
+                        yrows_top = parseInt(wid.model.get("_extrarows") / 2 + 1);
+                        yrows_bottom = parseInt(wid.model.get("_extrarows") / 2);
                     }
                     if (wid.model.get("_extracols") % 2 == 0) {
-                        xcols_left = wid.model.get("_extracols") / 2;
-                        xcols_right = wid.model.get("_extracols") / 2;
+                        xcols_left = parseInt(wid.model.get("_extracols") / 2);
+                        xcols_right = parseInt(wid.model.get("_extracols") / 2);
                     }
                     else {
-                        xcols_left = wid.model.get("_extracols") / 2 + 1;
-                        xcols_right = wid.model.get("_extracols") / 2;
+                        xcols_left = parseInt(wid.model.get("_extracols") / 2 + 1);
+                        xcols_right = parseInt(wid.model.get("_extracols") / 2);
                     }
                 }
                 console.log("coords: (" + x_coordinate + ", " + y_coordinate + ")");

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -227,8 +227,8 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             console.log(data_vbox);
             
             //Creates the label for the vertical slider with a static value of "Z range" (done in the same way as the other label)
-            var vslide_label = $('<input class="vslabel" type="text" readonly style="border:0">');
-            vslide_label.val("Z range");
+            var vslide_label = $('<div class="vslabel" type="text" readonly style="border:0">');
+            vslide_label.text("Z range: " + vrange);
             vslide_label.css("marginTop", "10px");
             vslide_label.css("marginBottom", "10px");
             //Creates the vertical slider using JQuery UI

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -413,8 +413,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             var topleft = "(" + this.model.get("_xcoord_absolute") + ", " + this.model.get("_ycoord_absolute") + ")";
             var right = this.model.get("_xcoord_absolute") + this.model.get("_ncols_currimg") - this.model.get("_extracols");
             var bottom = this.model.get("_ycoord_absolute") + this.model.get("_nrows_currimg") - this.model.get("_extrarows");
-            console.log(this.model.get("_nrows_currimg"), this.model.get("_ncols_currimg"));
-            console.log(this.model.get("_nrows"), this.model.get("_ncols"));
+            console.log(this.model.get("_extrarows"), this.model.get("_extracols"));
             console.log("\n");
             var topright = "(" + right + ", " + this.model.get("_ycoord_absolute") + ")";
             var bottomleft = "(" + this.model.get("_xcoord_absolute") + ", " + bottom + ")";

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -245,7 +245,11 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             var value = $("<div>"); value.text("Value: ");
             var val = $('<span class="img-value">');
             value.append(val);
-            text_content.append(xy); text_content.append(value);
+            var roi = $("<div>"); roi.text("ROI: ");
+            var corners = $('<span class="roi">');
+            roi.append(corners);
+            corners.css("whiteSpace", "pre");
+            text_content.append(xy); text_content.append(value); text_content.append(roi);
             data_vbox.append(text_content);
             console.log(data_vbox);
             
@@ -363,9 +367,12 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 }
             });
 
+            this.calc_roi();
+
             //Triggers on_pixval_change and on_img_change when the backend values of _pix_val and _b64value change.
             this.model.on("change:_pix_val", this.on_pixval_change, this);
             this.model.on("change:_b64value", this.on_img_change, this);
+            this.model.on("change:_b64value", this.calc_roi, this);
         },
 
         /*If the text of the coordinate fields (x_coord and y_coord) contain empty strings, the value field will 
@@ -394,6 +401,18 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             console.log("Executing on_img_change");
             var src = "data:image/" + this.model.get("_format") + ";base64," + this.model.get("_b64value");
             this.$el.find(".curr-img").attr("src", src);
+        },
+
+        calc_roi: function() {
+            var topleft = "(" + this.model.get("_xcoord_absolute") + ", " + this.model.get("_ycoord_absolute") + ")";
+            var right = this.model.get("_xcoord_absolute") + this.model.get("_ncols_currimg") - this.model.get("_extracols");
+            var bottom = this.model.get("_ycoord_absolute") + this.model.get("_nrows_currimg") - this.model.get("_extrarows");
+            var topright = "(" + right + ", " + this.model.get("_ycoord_absolute") + ")";
+            var bottomleft = "(" + this.model.get("_xcoord_absolute") + ", " + bottom + ")";
+            var bottomright = "(" + right + ", " + bottom + ")";
+            var corns = topleft + "  " + topright + "\n        " + bottomleft + "  " + bottomright;
+            console.log(corns);
+            this.$el.find(".roi").text(corns);
         }
 	
     });

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -42,14 +42,23 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             //Adds the widget to the display area.
             this.$el.append(widget_area);
 
+            //Add a container for the image and the selection box
+            var img_container = $('<div class="img-container">');
+            img_vbox.append(img_container);
+            img_container.css({
+                position: "relative",
+                width: this.model.get("width"),
+                height: this.model.get("height"),
+                margin: "10px"
+            });
+
             //Creates the image stored in the initial value of _b64value and adds it to img_vbox.
             var img = $('<img class="curr-img">');
             var image_src = "data:image/" + this.model.get("_format") + ";base64," + this.model.get("_b64value")
             img.attr("src", image_src);
             
-            img.css("margin", "10px");
             img.width(this.model.get("width")); img.height(this.model.get("height"));
-            img_vbox.append(img);
+            img_container.append(img);
 
             //Creates a read-only input field with no border to dynamically display the value of the horizontal slider.
             var hslide_label = $('<input class="hslabel" type="text" readonly style="border:0">'); 
@@ -80,6 +89,102 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             //Adds hslide_html (the slider) and hslide_label (the label) to img_vbox
             img_vbox.append(hslide_html);
             img_vbox.append(hslide_label);
+
+            //Creates a zoom button and a reset button after the label
+            var zoom_button = $('<button class="zoom-button">');
+            zoom_button.button({
+                label: "Zoom",
+                disabled: false
+            });
+            zoom_button.css("margin", "10px");
+            img_vbox.append(zoom_button);
+            zoom_button.click(function() {
+                var zoom_val = wid.model.get("_zoom_click");
+                if (zoom_val < Number.MAX_SAFE_INTEGER) {
+                    zoom_val++;
+                }
+                else {
+                    zoom_val = 0;
+                }
+                wid.model.set("_zoom_click", zoom_val);
+                wid.touch();
+                select.remove();
+                console.log("Select removed");
+            });
+
+            var reset_button = $('<button class="reset-button">')
+            reset_button.button({
+                label: "Reset",
+                disabled: false
+            });
+            reset_button.css("margin", "10px");
+            img_vbox.append(reset_button);
+            reset_button.click(function() {
+                var reset_val = wid.model.get("_reset_click");
+                if (reset_val < Number.MAX_SAFE_INTEGER) {
+                    reset_val++;
+                }
+                else {
+                    reset_val = 0;
+                }
+                wid.model.set("_reset_click", reset_val);
+                wid.touch();
+                select.remove();
+                console.log("Image reset");
+            });
+
+            //Adds the selection box and changes its size as the mouse moves over the image
+            var select = $('<div class="selection-box">');
+
+            img.on("dragstart", false);
+
+            img.on("mousedown", function(event) {
+                console.log("Click 1");
+                var click_x = event.offsetX;
+                var click_y = event.offsetY;
+                
+                select.css({
+                    "top": click_y,
+                    "left": click_x,
+                    "width": 0,
+                    "height": 0,
+                    "position": "absolute",
+                    "pointerEvents": "none"
+                });
+                
+                select.appendTo(img_container);
+
+                img.on("mousemove", function(event) {
+                    console.log("Mouse moving");
+                    var move_x = event.offsetX;
+                    var move_y = event.offsetY;
+                    var width = Math.abs(move_x - click_x);
+                    var height = Math.abs(move_y - click_y);
+                    var new_x, new_y;
+
+                    new_x = (move_x < click_x) ? (click_x - width) : click_x;
+                    new_y = (move_y < click_y) ? (click_y - height) : click_y;
+
+                    select.css({
+                        "width": width - 1,
+                        "height": height - 1,
+                        "top": new_y,
+                        "left": new_x,
+                        "background": "transparent",
+                        "border": "2px solid red"
+                    });
+
+                    wid.model.set("_offXtop", parseInt(select.css("left"), 10));
+                    wid.model.set("_offYtop", parseInt(select.css("top"), 10));
+                    wid.model.set("_offXbottom", parseInt(select.css("left"), 10) + select.width());
+                    wid.model.set("_offYbottom", parseInt(select.css("top"), 10) + select.height());
+                    wid.touch();
+
+                }).on("mouseup", function(event) {
+                    console.log("Click 2");
+                    img.off("mousemove");
+                });
+            });
 
             console.log(img_vbox);
             console.log("done with img box");

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -298,19 +298,21 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 wid.model.set("_offsetY", event.offsetY);
                 wid.touch();
 
-                console.log(wid.model.get("_extrarows"), wid.model.get("_extracols"));
+                //console.log(wid.model.get("_extrarows"), wid.model.get("_extracols"));
                 var yrows_top, yrows_bottom, xcols_left, xcols_right, x_coordinate, y_coordinate;
                 x_coordinate = Math.floor(event.offsetX*1./(wid.model.get("width"))*(wid.model.get("_ncols_currimg")));
                 y_coordinate = Math.floor(event.offsetY*1./(wid.model.get("height"))*(wid.model.get("_nrows_currimg")));
 
                 //All of this logic is used to get the correct coordinates for images containing buffer rows/columns.
                 if (wid.model.get("_extrarows") == 0 && wid.model.get("_extracols") == 0) {
+                    //console.log("No extra rows/cols");
                     yrows_top = 0;
                     yrows_bottom = Number.MAX_SAFE_INTEGER;
                     xcols_left = 0;
                     xcols_right = Number.MAX_SAFE_INTEGER;
                 }
                 else if (wid.model.get("_extrarows") != 0 && wid.model.get("_extracols") == 0) {
+                    //console.log("Extra Rows");
                     if (wid.model.get("_extrarows") % 2 == 0) {
                         yrows_top = parseInt(wid.model.get("_extrarows") / 2);
                         yrows_bottom = parseInt(wid.model.get("_extrarows") / 2);
@@ -323,6 +325,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                     xcols_right = Number.MAX_SAFE_INTEGER;
                 }
                 else if (wid.model.get("_extrarows") == 0 && wid.model.get("_extracols") != 0) {
+                    //console.log("Extra Cols");
                     if (wid.model.get("_extracols") % 2 == 0) {
                         xcols_left = parseInt(wid.model.get("_extracols") / 2);
                         xcols_right = parseInt(wid.model.get("_extracols") / 2);
@@ -335,6 +338,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                     yrows_bottom = Number.MAX_SAFE_INTEGER;
                 }
                 else {
+                    //console.log("Extra Rows/Cols");
                     if (wid.model.get("_extrarows") % 2 == 0) {
                         yrows_top = parseInt(wid.model.get("_extrarows") / 2);
                         yrows_bottom = parseInt(wid.model.get("_extrarows") / 2);
@@ -381,7 +385,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
           displayed in the value field.
         */
         on_pixval_change: function() {
-            console.log("Executing on_pixval_change");
+            //console.log("Executing on_pixval_change");
             if (this.$el.find(".img-offsetx").text() == "" && this.$el.find(".img-offsety").text() == "") {
                 this.$el.find(".img-value").text("");
             }
@@ -398,15 +402,20 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
         /*When _b64value changes on the backend, this function creates a new source string for the image (based
           on the new value of _b64value). This new source then replaces the old source of the image.*/
         on_img_change: function() {
-            console.log("Executing on_img_change");
+            //console.log("Executing on_img_change");
             var src = "data:image/" + this.model.get("_format") + ";base64," + this.model.get("_b64value");
             this.$el.find(".curr-img").attr("src", src);
         },
 
         calc_roi: function() {
+            //console.log(this.model.get("_ncols_currimg"), this.model.get("_extracols"));
+            //console.log(this.model.get("_nrows_currimg"), this.model.get("_extrarows"));
             var topleft = "(" + this.model.get("_xcoord_absolute") + ", " + this.model.get("_ycoord_absolute") + ")";
             var right = this.model.get("_xcoord_absolute") + this.model.get("_ncols_currimg") - this.model.get("_extracols");
             var bottom = this.model.get("_ycoord_absolute") + this.model.get("_nrows_currimg") - this.model.get("_extrarows");
+            console.log(this.model.get("_nrows_currimg"), this.model.get("_ncols_currimg"));
+            console.log(this.model.get("_nrows"), this.model.get("_ncols"));
+            console.log("\n");
             var topright = "(" + right + ", " + this.model.get("_ycoord_absolute") + ")";
             var bottomleft = "(" + this.model.get("_xcoord_absolute") + ", " + bottom + ")";
             var bottomright = "(" + right + ", " + bottom + ")";

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -120,7 +120,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             });
 
             //Creates and adds a button after zoom_button for zooming into all images
-            var zoomall_button = $('<button class="zoom-button">');
+            /*var zoomall_button = $('<button class="zoom-button">');
             zoomall_button.button({
                 label: "Zoom All",
                 disabled: false
@@ -129,7 +129,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             img_vbox.append(zoomall_button);
             /*When zoomall_button is clicked, the synced variable _zoomall_click is either incremented or
               reset to 0. This triggers the zoomAll python function. The selection box is also removed.
-            */
+            
             zoomall_button.click(function() {
                 var zoomall_val = wid.model.get("_zoomall_click");
                 if (zoomall_val < Number.MAX_SAFE_INTEGER) {
@@ -142,7 +142,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 wid.touch();
                 select.remove();
                 console.log("All images zoomed");
-            });
+            });*/
 
             //Creates and adds a button after zoomall_button for reseting all displayed images.
             var reset_button = $('<button class="reset-button">')

--- a/ipywe/imageslider.js
+++ b/ipywe/imageslider.js
@@ -81,7 +81,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             //Sets the label's initial value to the initial value of the slider and adds a left margin to the label
             hslide_label.val(hslide_html.slider("value"));
             hslide_label.css("marginLeft", "7px");
-            hslide_label.width("30%");
+            hslide_label.width("15%");
             //Makes the slider's handle a blue circle and adds a 10 pixel margin to the slider
             var hslide_handle = hslide_html.find(".ui-slider-handle");
             hslide_handle.css("borderRadius", "50%");
@@ -93,7 +93,7 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
             img_vbox.append(hslide_html);
             img_vbox.append(hslide_label);
 
-            //Creates a zoom button and a reset button after the label
+            //Creates a zoom button, a zoom all button, and a reset button after the label
             var zoom_button = $('<button class="zoom-button">');
             zoom_button.button({
                 label: "Zoom",
@@ -112,7 +112,28 @@ define("imgslider", ["jupyter-js-widgets"], function(widgets) {
                 wid.model.set("_zoom_click", zoom_val);
                 wid.touch();
                 select.remove();
-                console.log("Select removed");
+                console.log("Zoomed");
+            });
+
+            var zoomall_button = $('<button class="zoom-button">');
+            zoomall_button.button({
+                label: "Zoom All",
+                disabled: false
+            });
+            zoomall_button.css("margin", "10px");
+            img_vbox.append(zoomall_button);
+            zoomall_button.click(function() {
+                var zoomall_val = wid.model.get("_zoomall_click");
+                if (zoomall_val < Number.MAX_SAFE_INTEGER) {
+                    zoomall_val++;
+                }
+                else {
+                    zoomall_val = 0;
+                }
+                wid.model.set("_zoomall_click", zoomall_val);
+                wid.touch();
+                select.remove();
+                console.log("All images zoomed");
             });
 
             var reset_button = $('<button class="reset-button">')

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -211,8 +211,6 @@ class ImageSlider(ipyw.DOMWidget):
 
         Finally, the zoomed image data is converted to a displayable image by calling the getimg_bytes function."""
 
-        self._extrarows = 0
-        self._extracols = 0
         select_width = self.right - self.left
         select_height = self.bottom - self.top
         if select_width == 0 and select_height == 0:
@@ -237,6 +235,8 @@ class ImageSlider(ipyw.DOMWidget):
             self.ybuff = addtop
             self._nrows_currimg = self._ncols
             self._ncols_currimg = self._ncols
+            self._extrarows = diff
+            self._extracols = 0
             extrarows_top = np.full((addtop, self._ncols), 1)
             extrarows_bottom = np.full((addbottom, self._ncols), 1)
             self.curr_img_data = np.vstack((extrarows_top, self.curr_img_data, extrarows_bottom))
@@ -251,14 +251,12 @@ class ImageSlider(ipyw.DOMWidget):
             self.xbuff = addleft
             self.ybuff = 0
             self._nrows_currimg = self._nrows
-            self._ncols_currimg = self._ncols
+            self._ncols_currimg = self._nrows
+            self._extrarows = 0
+            self._extracols = diff
             extrarows_left = np.full((self._nrows, addleft), 1)
             extrarows_right = np.full((self._nrows, addright), 1)
             self.curr_img_data = np.hstack((extrarows_left, self.curr_img_data, extrarows_right))
-        if self._nrows_currimg > self._nrows:
-            self._extrarows = self._nrows_currimg - self._nrows
-        if self._ncols_currimg > self._ncols:
-            self._extracols = self._ncols_currimg - self._ncols
         self._b64value = self.getimg_bytes()
         #self.curr_img_series[self.img_index] = self.curr_img_data
         return

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -235,6 +235,8 @@ class ImageSlider(ipyw.DOMWidget):
                 addbottom = int(diff / 2)
             self.xbuff = 0
             self.ybuff = addtop
+            self._nrows_currimg = self._ncols
+            self._ncols_currimg = self._ncols
             extrarows_top = np.full((addtop, self._ncols), 1)
             extrarows_bottom = np.full((addbottom, self._ncols), 1)
             self.curr_img_data = np.vstack((extrarows_top, self.curr_img_data, extrarows_bottom))
@@ -248,10 +250,11 @@ class ImageSlider(ipyw.DOMWidget):
                 addright = int(diff / 2)
             self.xbuff = addleft
             self.ybuff = 0
+            self._nrows_currimg = self._nrows
+            self._ncols_currimg = self._ncols
             extrarows_left = np.full((self._nrows, addleft), 1)
             extrarows_right = np.full((self._nrows, addright), 1)
             self.curr_img_data = np.hstack((extrarows_left, self.curr_img_data, extrarows_right))
-        self._nrows_currimg, self._ncols_currimg = self.curr_img_data.shape
         if self._nrows_currimg > self._nrows:
             self._extrarows = self._nrows_currimg - self._nrows
         if self._ncols_currimg > self._ncols:

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -174,6 +174,8 @@ class ImageSlider(ipyw.DOMWidget):
 
     @observe("_zoom_click")
     def zoomImg(self, change):
+        self._extrarows = 0
+        self._extracols = 0
         left = int(self._offXtop*1./self.width * self._ncols_currimg)
         right = int(self._offXbottom*1./self.width*self._ncols_currimg)
         top = int(self._offYtop*1./self.height*self._nrows_currimg)
@@ -227,6 +229,8 @@ class ImageSlider(ipyw.DOMWidget):
 
     @observe("_zoomall_click")
     def zoomAll(self, change):
+        self._extrarows = 0
+        self._extracols = 0
         left = int(self._offXtop*1./self.width * self._ncols_currimg)
         right = int(self._offXbottom*1./self.width*self._ncols_currimg)
         top = int(self._offYtop*1./self.height*self._nrows_currimg)

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -44,6 +44,7 @@ class ImageSlider(ipyw.DOMWidget):
     _ncols_currimg = Integer().tag(sync=True)
     _xcoord_absolute = Integer(0).tag(sync=True)
     _ycoord_absolute = Integer(0).tag(sync=True)
+    _vslide_reset = Integer(0).tag(sync=True)
   
     
     def __init__(self, image_series, width, height):
@@ -349,6 +350,8 @@ class ImageSlider(ipyw.DOMWidget):
         self.ybuff = 0
         self._xcoord_absolute = 0
         self._ycoord_absolute = 0
+        self.get_series_minmax()
+        self._vslide_reset += 1
         self.update_image(None)
         return
 

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -37,6 +37,8 @@ class ImageSlider(ipyw.DOMWidget):
     _extracols = Integer(0).tag(sync=True)
     _nrows_currimg = Integer().tag(sync=True)
     _ncols_currimg = Integer().tag(sync=True)
+    _xcoord_absolute = Integer(0).tag(sync=True)
+    _ycoord_absolute = Integer(0).tag(sync=True)
 
     height = Integer().tag(sync=True)
     img_index = Integer(0).tag(sync=True)
@@ -45,6 +47,14 @@ class ImageSlider(ipyw.DOMWidget):
     
     def __init__(self, image_series, width, height):
         """Constructor method for setting the necessary member variables that are synced between the front- and back-ends.
+        Creates the following non-synced member variables:
+
+            *image_series: the list containing the original series of image objects passed by the image_series parameter. This variable is not changed in the code to preserve the original data.
+            *curr_img_series: the list containing the image series that is currently being displayed by the widget. Contains image objects (if no images have been changed or if they've been reset), numpy arrays corresponding to zoomed images, or a combination of the two (if only single images have been changed)
+            *current_img: the image object or corresponding numpy array of data that is currently being displayed
+            *arr: a numpy array containing the data for the current image that does not contain buffer rows/columns
+            *curr_img_data: a numpy array containing the data for the current image, including buffer rows/columns
+
         
         Parameters:
         
@@ -159,10 +169,10 @@ class ImageSlider(ipyw.DOMWidget):
 
     @observe("_zoom_click")
     def zoomImg(self, change):
-        left = int(self._offXtop*1./self.width * self._ncols)
-        right = int(self._offXbottom*1./self.width*self._ncols)
-        top = int(self._offYtop*1./self.height*self._nrows)
-        bottom = int(self._offYbottom*1./self.height*self._nrows)
+        left = int(self._offXtop*1./self.width * self._ncols_currimg)
+        right = int(self._offXbottom*1./self.width*self._ncols_currimg)
+        top = int(self._offYtop*1./self.height*self._nrows_currimg)
+        bottom = int(self._offYbottom*1./self.height*self._nrows_currimg)
         if (right - left) == 0 and (bottom - top) == 0:
             right = left + 1
             bottom = top + 1
@@ -170,7 +180,9 @@ class ImageSlider(ipyw.DOMWidget):
             right = left + 1
         if (bottom - top) == 0:
             bottom = top + 1
-        self.arr = self.arr[top:bottom, left:right]
+        self.arr = self.curr_img_data[top:bottom, left:right]
+        self._xcoord_absolute += left
+        self._ycoord_absolute += top
         self._nrows, self._ncols = self.arr.shape
         self.curr_img_data = self.arr.copy()
         if self._ncols > self._nrows:
@@ -206,10 +218,10 @@ class ImageSlider(ipyw.DOMWidget):
 
     @observe("_zoomall_click")
     def zoomAll(self, change):
-        left = int(self._offXtop*1./self.width * self._ncols)
-        right = int(self._offXbottom*1./self.width*self._ncols)
-        top = int(self._offYtop*1./self.height*self._nrows)
-        bottom = int(self._offYbottom*1./self.height*self._nrows)
+        left = int(self._offXtop*1./self.width * self._ncols_currimg)
+        right = int(self._offXbottom*1./self.width*self._ncols_currimg)
+        top = int(self._offYtop*1./self.height*self._nrows_currimg)
+        bottom = int(self._offYbottom*1./self.height*self._nrows_currimg)
         if (right - left) == 0 and (bottom - top) == 0:
             right = left + 1
             bottom = top + 1

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -177,12 +177,12 @@ class ImageSlider(ipyw.DOMWidget):
             self.arr = self.current_img.copy().astype("float")
         else:
             self.arr = self.current_img.data.copy().astype("float")
-        self._nrows, self._ncols = self.arr.shape
-        self._nrows_currimg, self._ncols_currimg = self.arr.shape
         self.curr_img_data = self.arr.copy()
         if self.left != -1 and self.right != -1 and self.top != -1 and self.bottom != -1:
             self.handle_zoom()
             return
+        self._nrows, self._ncols = self.arr.shape
+        self._nrows_currimg, self._ncols_currimg = self.arr.shape
         self._b64value = self.getimg_bytes()
         return
 
@@ -195,6 +195,7 @@ class ImageSlider(ipyw.DOMWidget):
         self.bottom = int(self._offYbottom*1./self.height*self._nrows_currimg)
         self._xcoord_absolute += (self.left - self.xbuff)
         self._ycoord_absolute += (self.top - self.ybuff)
+        #self._nrows
         self.update_image(None)
 
     def handle_zoom(self):
@@ -221,7 +222,7 @@ class ImageSlider(ipyw.DOMWidget):
             select_width = 1
         if select_height == 0:
             select_height = 1
-        self.arr = self.curr_img_series[self.img_index].data[self._ycoord_absolute:(self._ycoord_absolute + select_height), self._xcoord_absolute:(self._xcoord_absolute + select_width)]
+        self.arr = self.arr[self._ycoord_absolute:(self._ycoord_absolute + select_height), self._xcoord_absolute:(self._xcoord_absolute + select_width)]
         self._nrows, self._ncols = self.arr.shape
         self.curr_img_data = self.arr.copy()
         if self._ncols > self._nrows:

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -220,8 +220,8 @@ class ImageSlider(ipyw.DOMWidget):
             else:
                 addtop = int(diff / 2 + 1)
                 addbottom = int(diff / 2)
-            self.ybuff = addtop
             self.xbuff = 0
+            self.ybuff = addtop
             extrarows_top = np.full((addtop, self._ncols), 1)
             extrarows_bottom = np.full((addbottom, self._ncols), 1)
             self.curr_img_data = np.vstack((extrarows_top, self.curr_img_data, extrarows_bottom))
@@ -289,8 +289,8 @@ class ImageSlider(ipyw.DOMWidget):
                 else:
                     addtop = diff / 2 + 1
                     addbottom = diff / 2
-                self.ybuff = addtop
                 self.xbuff = 0
+                self.ybuff = addtop
                 extrarows_top = np.full((addtop, self._ncols), 1)
                 extrarows_bottom = np.full((addbottom, self._ncols), 1)
                 newimg = np.vstack((extrarows_top, newimg, extrarows_bottom))

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -61,6 +61,7 @@ class ImageSlider(ipyw.DOMWidget):
         self.arr = self.current_img.data.copy()
         self.curr_img_data = self.arr.copy()
         self._nrows, self._ncols = self.arr.shape
+        self._nrows_currimg, self._ncols_currimg = self.arr.shape
         self._img_min, self._img_max = int(np.min(self.arr)), int(np.max(self.arr))
         self.update_image(None);
         super(ImageSlider, self).__init__()
@@ -79,7 +80,7 @@ class ImageSlider(ipyw.DOMWidget):
             row = int(self._offsetY*1./self.height * self._nrows_currimg)
             if col >= self.curr_img_data.shape[1]: col = self.curr_img_data.shape[1]-1
             if row >= self.curr_img_data.shape[0]: row = self.curr_img_data.shape[0]-1
-            self._pix_val = self.curr_img_data[row, col]
+            self._pix_val = float(self.curr_img_data[row, col])
             self._err = ""
         except Exception:
             self._err = self.handle_error()
@@ -172,7 +173,6 @@ class ImageSlider(ipyw.DOMWidget):
             extrarows_bottom = np.full((addbottom, self._ncols), 1)
             self.curr_img_data = np.vstack((extrarows_top, self.curr_img_data, extrarows_bottom))
         else:
-            print("nrows > ncols")
             diff = self._nrows - self._ncols
             if diff % 2 == 0:
                 addleft = diff / 2
@@ -248,7 +248,7 @@ class ImageSlider(ipyw.DOMWidget):
 
     @observe("_reset_click")
     def resetImg(self, change):
-        self.curr_img_series = self.image_series
+        self.curr_img_series = list(self.image_series)
         self._extrarows = 0
         self._extracols = 0 
         self.update_image(None)

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -77,9 +77,9 @@ class ImageSlider(ipyw.DOMWidget):
             #arr = self.current_img.data
             col = int(self._offsetX*1./self.width * self._ncols_currimg)
             row = int(self._offsetY*1./self.height * self._nrows_currimg)
-            if col >= self.arr.shape[1]: col = self.arr.shape[1]-1
-            if row >= self.arr.shape[0]: row = self.arr.shape[0]-1
-            self._pix_val = self.arr[col, row]
+            if col >= self.curr_img_data.shape[1]: col = self.curr_img_data.shape[1]-1
+            if row >= self.curr_img_data.shape[0]: row = self.curr_img_data.shape[0]-1
+            self._pix_val = self.curr_img_data[row, col]
             self._err = ""
         except Exception:
             self._err = self.handle_error()
@@ -172,6 +172,7 @@ class ImageSlider(ipyw.DOMWidget):
             extrarows_bottom = np.full((addbottom, self._ncols), 1)
             self.curr_img_data = np.vstack((extrarows_top, self.curr_img_data, extrarows_bottom))
         else:
+            print("nrows > ncols")
             diff = self._nrows - self._ncols
             if diff % 2 == 0:
                 addleft = diff / 2

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -177,6 +177,7 @@ class ImageSlider(ipyw.DOMWidget):
             extrarows_left = np.full((self._nrows, addleft), 1)
             extrarows_right = np.full((self._nrows, addright), 1)
             self.curr_img_data = np.hstack((extrarows_left, self.curr_img_data, extrarows_right))
+        self.curr_img_series[self.img_index] = self.curr_img_data
         self._b64value = self.getimg_bytes()
         return
 

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -129,6 +129,7 @@ class ImageSlider(ipyw.DOMWidget):
         
         self.current_img = self.image_series[self.img_index]
         self.arr = self.current_img.data.copy()
+        self._nrows, self._ncols = self.arr.shape
         self.curr_img_data = self.arr
         self._b64value = self.getimg_bytes()
         return

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -49,13 +49,13 @@ class ImageSlider(ipyw.DOMWidget):
             *height: an integer that is used to set the height of the image and UI elements."""
         
         self.image_series = image_series
-        self.curr_img_series = self.image_series
+        self.curr_img_series = list(self.image_series)
         self.width = width
         self.height = height
         self._series_max = len(self.image_series) - 1
         self.current_img = self.image_series[self.img_index]
         self.arr = self.current_img.data.copy()
-        self.curr_img_data = self.arr
+        self.curr_img_data = self.arr.copy()
         self._nrows, self._ncols = self.arr.shape
         self._img_min, self._img_max = int(np.min(self.arr)), int(np.max(self.arr))
         self.update_image(None);
@@ -135,7 +135,7 @@ class ImageSlider(ipyw.DOMWidget):
         else:
             self.arr = self.current_img.data.copy()
         self._nrows, self._ncols = self.arr.shape
-        self.curr_img_data = self.arr
+        self.curr_img_data = self.arr.copy()
         self._b64value = self.getimg_bytes()
         return
 
@@ -154,7 +154,7 @@ class ImageSlider(ipyw.DOMWidget):
             bottom = top + 1
         self.arr = self.arr[top:bottom, left:right]
         self._nrows, self._ncols = self.arr.shape
-        self.curr_img_data = self.arr
+        self.curr_img_data = self.arr.copy()
         if self._ncols > self._nrows:
             diff = self._ncols - self._nrows
             if diff % 2 == 0:

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -54,6 +54,7 @@ class ImageSlider(ipyw.DOMWidget):
             *current_img: the image object or corresponding numpy array of data that is currently being displayed
             *arr: a numpy array containing the data for the current image that does not contain buffer rows/columns
             *curr_img_data: a numpy array containing the data for the current image, including buffer rows/columns
+            *xbuff and ybuff: the number of buffer rows in the previously displayed image
 
         
         Parameters:
@@ -72,6 +73,8 @@ class ImageSlider(ipyw.DOMWidget):
         self.curr_img_data = self.arr.copy()
         self._nrows, self._ncols = self.arr.shape
         self._nrows_currimg, self._ncols_currimg = self.arr.shape
+        self.ybuff = 0
+        self.xbuff = 0
         self._img_min, self._img_max = int(np.min(self.arr)), int(np.max(self.arr))
         self.get_series_minmax()
         self.update_image(None)
@@ -180,30 +183,34 @@ class ImageSlider(ipyw.DOMWidget):
             right = left + 1
         if (bottom - top) == 0:
             bottom = top + 1
+        self._xcoord_absolute += (left - self.xbuff)
+        self._ycoord_absolute += (top - self.ybuff)
         self.arr = self.curr_img_data[top:bottom, left:right]
-        self._xcoord_absolute += left
-        self._ycoord_absolute += top
         self._nrows, self._ncols = self.arr.shape
         self.curr_img_data = self.arr.copy()
         if self._ncols > self._nrows:
             diff = self._ncols - self._nrows
             if diff % 2 == 0:
-                addtop = diff / 2
-                addbottom = diff / 2
+                addtop = int(diff / 2)
+                addbottom = int(diff / 2)
             else:
-                addtop = diff / 2 + 1
-                addbottom = diff / 2
+                addtop = int(diff / 2 + 1)
+                addbottom = int(diff / 2)
+            self.ybuff = addtop
+            self.xbuff = 0
             extrarows_top = np.full((addtop, self._ncols), 1)
             extrarows_bottom = np.full((addbottom, self._ncols), 1)
             self.curr_img_data = np.vstack((extrarows_top, self.curr_img_data, extrarows_bottom))
         else:
             diff = self._nrows - self._ncols
             if diff % 2 == 0:
-                addleft = diff / 2
-                addright = diff / 2
+                addleft = int(diff / 2)
+                addright = int(diff / 2)
             else:
-                addleft = diff / 2 + 1
-                addright = diff / 2
+                addleft = int(diff / 2 + 1)
+                addright = int(diff / 2)
+            self.xbuff = addleft
+            self.ybuff = 0
             extrarows_left = np.full((self._nrows, addleft), 1)
             extrarows_right = np.full((self._nrows, addright), 1)
             self.curr_img_data = np.hstack((extrarows_left, self.curr_img_data, extrarows_right))
@@ -229,6 +236,8 @@ class ImageSlider(ipyw.DOMWidget):
             right = left + 1
         if (bottom - top) == 0:
             bottom = top + 1
+        self._xcoord_absolute += (left - self.xbuff)
+        self._ycoord_absolute += (top - self.ybuff)
         new_series = []
         self._nrows = bottom - top
         self._ncols = right - left
@@ -246,6 +255,8 @@ class ImageSlider(ipyw.DOMWidget):
                 else:
                     addtop = diff / 2 + 1
                     addbottom = diff / 2
+                self.ybuff = addtop
+                self.xbuff = 0
                 extrarows_top = np.full((addtop, self._ncols), 1)
                 extrarows_bottom = np.full((addbottom, self._ncols), 1)
                 newimg = np.vstack((extrarows_top, newimg, extrarows_bottom))
@@ -257,6 +268,8 @@ class ImageSlider(ipyw.DOMWidget):
                 else:
                     addleft = diff / 2 + 1
                     addright = diff / 2
+                self.xbuff = addleft
+                self.ybuff = 0
                 extrarows_left = np.full((self._nrows, addleft), 1)
                 extrarows_right = np.full((self._nrows, addright), 1)
                 newimg = np.hstack((extrarows_left, newimg, extrarows_right))
@@ -275,6 +288,10 @@ class ImageSlider(ipyw.DOMWidget):
         self.curr_img_series = list(self.image_series)
         self._extrarows = 0
         self._extracols = 0 
+        self.xbuff = 0
+        self.ybuff = 0
+        self._xcoord_absolute = 0
+        self._ycoord_absolute = 0
         self.update_image(None)
         return
 

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -131,7 +131,7 @@ class ImageSlider(ipyw.DOMWidget):
         
         self.current_img = self.curr_img_series[self.img_index]
         if type(self.current_img) is np.ndarray:
-            self.arr = self.current_img
+            self.arr = self.current_img.copy()
         else:
             self.arr = self.current_img.data.copy()
         self._nrows, self._ncols = self.arr.shape

--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -63,10 +63,22 @@ class ImageSlider(ipyw.DOMWidget):
         self._nrows, self._ncols = self.arr.shape
         self._nrows_currimg, self._ncols_currimg = self.arr.shape
         self._img_min, self._img_max = int(np.min(self.arr)), int(np.max(self.arr))
-        self.update_image(None);
+        self.get_series_minmax()
+        self.update_image(None)
         super(ImageSlider, self).__init__()
         return
-    
+
+    def get_series_minmax(self):
+        for i in self.image_series:
+            img = i.data.copy()
+            curr_min = int(np.min(img))
+            curr_max = int(np.max(img))
+            if curr_min < self._img_min:
+                self._img_min = curr_min
+            if curr_max > self._img_max:
+                self._img_max = curr_max
+        return
+                
     #This function is called when the values of _offsetX and/or _offsetY change.
     @observe("_offsetX", "_offsetY")
     def get_val(self, change):


### PR DESCRIPTION
Here's the completed new version of the ImageSlider widget. It implements the zooming algorithm from the ImageDisplay widget, although it is slightly altered to allow for all images to be zoomed at once without the image series needing to be copied. Also, this pull request implements a ROI field that displays the coordinates of the four corners of the currently displayed image. These coordinates are with respect to the original image, not the zoomed image.

For more details on development and changes, see #14.