### PR TITLE
added example code showing that works in both devel and distribution,…

### DIFF
--- a/ipywe/example.py
+++ b/ipywe/example.py
@@ -1,0 +1,34 @@
+import ipywidgets as widgets
+from traitlets import Unicode
+
+devel = 1
+# devel = 0
+
+@widgets.register('hello.Hello')
+class HelloWorld(widgets.DOMWidget):
+    """"""
+    _view_name = Unicode('HelloView').tag(sync=True)
+    _model_name = Unicode('HelloModel').tag(sync=True)
+    if devel:
+        _view_module = Unicode('example').tag(sync=True)
+        _model_module = Unicode('example').tag(sync=True)
+    else:
+        _view_module = Unicode('ipywe').tag(sync=True)
+        _model_module = Unicode('ipywe').tag(sync=True)
+    _view_module_version = Unicode('^0.1.0').tag(sync=True)
+    _model_module_version = Unicode('^0.1.0').tag(sync=True)
+    value = Unicode('Hello World!').tag(sync=True)
+
+
+if devel:
+    from IPython.display import display, HTML
+    def get_js():
+        import os
+        js = open(os.path.join(os.path.dirname(__file__), "..", "js", "src", "example.js")).read()
+        return js.decode("UTF-8")
+
+    def run_js():
+        js = get_js()
+        display(HTML("<script>"+js+"</script>"))
+        return
+    run_js()

--- a/js/src/example.js
+++ b/js/src/example.js
@@ -1,0 +1,62 @@
+var devel=1;
+// var devel=0;
+var widgets = require('jupyter-js-widgets');
+var _ = require('underscore');
+
+// Custom Model. Custom widgets models must at least provide default values
+// for model attributes, including
+//
+//  - `_view_name`
+//  - `_view_module`
+//  - `_view_module_version`
+//
+//  - `_model_name`
+//  - `_model_module`
+//  - `_model_module_version`
+//
+//  when different from the base class.
+
+// When serialiazing the entire widget state for embedding, only values that
+// differ from the defaults will be specified.
+var HelloModel = widgets.DOMWidgetModel.extend({
+    defaults: _.extend(_.result(this, 'widgets.DOMWidgetModel.prototype.defaults'), {
+	_model_name : 'HelloModel',
+	_view_name : 'HelloView',
+	_model_module : 'ipywe',
+	_view_module : 'ipywe',
+	_model_module_version : '0.1.0',
+	_view_module_version : '0.1.0',
+	value : 'Hello World'
+    })
+});
+
+
+// Custom View. Renders the widget model.
+var HelloView = widgets.DOMWidgetView.extend({
+    render: function() {
+	this.value_changed();
+	this.model.on('change:value', this.value_changed, this);
+    },
+
+    value_changed: function() {
+	this.el.textContent = this.model.get('value');
+    }
+});
+
+
+if (devel) {
+    require.undef("example");
+    define("example", ["jupyter-js-widgets"], function(widgets) {
+	return {
+	    HelloView: HelloView,
+	    HelloModel: HelloModel
+	}
+    });
+} else {
+    module.exports = {
+	HelloModel : HelloModel,
+	HelloView : HelloView
+    };
+}
+
+

--- a/js/src/loadwidgets.js
+++ b/js/src/loadwidgets.js
@@ -2,6 +2,7 @@
 module.exports = {};
 
 var loadedModules = [
+    require('./example'),
     require('./imgdisplay'),
     require('./imageslider'),
     require('./imgdatagraph'),

--- a/tests/test_helloworld.ipynb
+++ b/tests/test_helloworld.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "devel = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "if devel:\n",
+    "    import sys, os\n",
+    "    sys.path.insert(0, os.path.abspath(\"..\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywe.example\n",
+    "ipywe.example.HelloWorld()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
… differentiated only by a "devel" flag

Developing by using the distribution commands (see dev_js_update.sh) can be time-consuming because every update to the js code has to be installed and activated using the command (call this "distribution"). Before, we have done development without distribution by running js code at the bottom of the python module of the widget definition (devel). The code for "distribution" and "devel" is only slightly different.

Here we show an example code that can be used both for "distribution" and "devel". A flag "devel" is used in both the python module and the js module to switch between the two "modes". Changing the value of the flag alows for easy switching between the two modes.

This is especially useful for developing new widgets.
