### PR TITLE
Added the possibility to disable the entire ui

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/ipywe/fileselector.py
+++ b/ipywe/fileselector.py
@@ -140,13 +140,13 @@ class FileSelectorPanel:
         return body
 
 
-    def disabled_ui(self, disabled=True):
-        self.button_layout.disabled = disabled
-        self.ok.disabled = disabled
-        self.jumpto_input.disabled = disabled
-        self.enterdir.disabled = disabled
-        self.jumpto_button.disabled = disabled
-        self.select.disabled = disabled
+    def disable(self):
+        disable(self.panel)
+        return
+
+    def enable(self):
+        enable(self.panel)
+        return
 
     def changeDir(self, path):
         close(self.body)
@@ -237,13 +237,30 @@ div.output_subarea > div {margin: 0.4em;}
 
 def close(w):
     "recursively close a widget"
-    if hasattr(w, 'children'):
-        for c in w.children:
-            close(c)
-            continue
-    w.close()
+    recursive_op(w, lambda x: x.close())
     return
 
+def disable(w):
+    "recursively disable a widget"
+    def _(w):
+        w.disabled = True
+    recursive_op(w, _)
+    return
+
+def enable(w):
+    "recursively enable a widget"
+    def _(w):
+        w.disabled = False
+    recursive_op(w, _)
+    return
+
+def recursive_op(w, single_op):
+    if hasattr(w, 'children'):
+        for c in w.children:
+            recursive_op(c, single_op)
+            continue
+    single_op(w)
+    return
 
 def create_file_times(paths):
     """returns a list of file modify time"""

--- a/ipywe/fileselector.py
+++ b/ipywe/fileselector.py
@@ -74,6 +74,7 @@ class FileSelectorPanel:
         jumpto_button = ipyw.Button(description="Jump", layout=self.toolbar_button_layout)
         jumpto_button.on_click(self.handle_jumpto)
         jumpto = ipyw.HBox(children=[jumpto_input, jumpto_button], layout=self.toolbar_box_layout)
+        self.jumpto_button = jumpto_button
         if self.newdir_toolbar_button:
             # "new dir"
             self.newdir_input = newdir_input = ipyw.Text(
@@ -124,6 +125,14 @@ class FileSelectorPanel:
         self.panel = ipyw.VBox(children=[explanation, toolbar, lower_panel], layout=self.layout)
         wait.close()
         return
+
+    def disabled_ui(self, disabled=True):
+        self.button_layout.disabled = disabled
+        self.ok.disabled = disabled
+        self.jumpto_input.disabled = disabled
+        self.enterdir.disabled = disabled
+        self.jumpto_button.disabled = disabled
+        self.select.disabled = disabled
 
     def handle_jumpto(self, s):
         v = self.jumpto_input.value

--- a/tests/test_file_selector.ipynb
+++ b/tests/test_file_selector.ipynb
@@ -2,27 +2,79 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "import sys, os\n",
-    "# sys.path.insert(0, os.path.abspath('..'))\n",
+    "sys.path.insert(0, os.path.abspath('..'))\n",
     "import ipywe.fileselector"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "source": [
     "# Single file selector"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f0bb553046f4ac4a2d438125ade0789"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <style type=\"text/css\">\n",
+       "        .jupyter-widgets select option {font-family: \"Lucida Console\", Monaco, monospace;}\n",
+       "        div.output_subarea {padding: 0px;}\n",
+       "        div.output_subarea > div {margin: 0.4em;}\n",
+       "        </style>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cf6f32676dcb405eb687dfd1eb8e9c76"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.')\n",
     "fsel.show()"
@@ -31,7 +83,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "print fsel.selected"
@@ -39,7 +96,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "source": [
     "# Single directory selector"
    ]
@@ -47,7 +109,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', type='directory')\n",
@@ -57,7 +124,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "print fsel.selected"
@@ -65,7 +137,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "source": [
     "# Single directory selector with \"new directory\" button"
    ]
@@ -73,7 +150,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "fsel= ipywe.fileselector.FileSelectorPanel(\n",
@@ -84,7 +166,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "print fsel.selected"
@@ -92,7 +179,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "source": [
     "# Multiple files selector"
    ]
@@ -100,7 +192,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', multiple=True)\n",
@@ -110,7 +207,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "print fsel.selected"
@@ -118,7 +220,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "source": [
     "# Multiple directories selector"
    ]
@@ -126,7 +233,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', type='directory', multiple=True)\n",
@@ -136,7 +248,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
    "outputs": [],
    "source": [
     "print fsel.selected"
@@ -145,7 +262,11 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
    },
    "source": [
     "# Single file selector with callback"
@@ -153,9 +274,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "648440f13baa428f880d067f83448b84"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <style type=\"text/css\">\n",
+       "        .jupyter-widgets select option {font-family: \"Lucida Console\", Monaco, monospace;}\n",
+       "        div.output_subarea {padding: 0px;}\n",
+       "        div.output_subarea > div {margin: 0.4em;}\n",
+       "        </style>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3098d481763f41499ca14d1004cdda72"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<script>alert('Please select file(s)');</script>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "def callback(selected):\n",
     "    print selected\n",
@@ -164,9 +339,85 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "source": [
+    "# Disable file selector "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bc49ce5a4a364ae4a5ec53485c8e6222"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <style type=\"text/css\">\n",
+       "        .jupyter-widgets select option {font-family: \"Lucida Console\", Monaco, monospace;}\n",
+       "        div.output_subarea {padding: 0px;}\n",
+       "        div.output_subarea > div {margin: 0.4em;}\n",
+       "        </style>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2a2a25954094fdbae51dcb89ccc99ad"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', next=callback)\n",
+    "fsel.show()\n",
+    "\n",
+    "# we display the ui but disabled it. \n",
+    "fsel.disabled_ui(disabled=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# later, if we decide to enable the ui again\n",
+    "fsel.disabled_ui(disabled=False)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -188,6 +439,25 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.13"
+  },
+  "toc": {
+   "colors": {
+    "hover_highlight": "#DAA520",
+    "running_highlight": "#FF0000",
+    "selected_highlight": "#FFD700"
+   },
+   "moveMenuLeft": true,
+   "nav_menu": {
+    "height": "139px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": true,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/tests/test_file_selector.ipynb
+++ b/tests/test_file_selector.ipynb
@@ -158,8 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def callback(selected):\n",
-    "    print selected\n",
+    "def callback(selected): print selected\n",
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', next=callback)\n",
     "fsel.show()"
    ]
@@ -177,11 +176,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "def callback(selected): print selected\n",
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', next=callback)\n",
-    "fsel.show()\n",
-    "\n",
-    "# we display the ui but disabled it. \n",
-    "fsel.disabled_ui(disabled=True)"
+    "fsel.show()"
    ]
   },
   {
@@ -190,8 +187,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# later, if we decide to enable the ui again\n",
-    "fsel.disabled_ui(disabled=False)"
+    "# disable the UI \n",
+    "fsel.disable()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# enable the UI\n",
+    "fsel.enable()"
    ]
   },
   {


### PR DESCRIPTION
I noticed that inside a notebook, if more than 1 file selector is displayed at the same time, hidden one, will hide the other ones too as they use the same layout. This new feature allows to disable only one fileselector at the time. 