### PR TITLE
Files filtering and stay alive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ node_modules/
 ipywe.egg-info/
 ipywe/static/
 js/dist/
-
+.idea*

--- a/ipywe/fileselector.py
+++ b/ipywe/fileselector.py
@@ -37,6 +37,7 @@ class FileSelectorPanel:
             multiple=False, newdir_toolbar_button=False,
             custom_layout = None,
             filter={},
+            stay_alive=False,
     ):
         """
         Create FileSelectorPanel instance
@@ -55,6 +56,11 @@ class FileSelectorPanel:
             callback function to execute after the selection is selected
         newdir_toolbar_button : bool
             If true, a button to create new directory is added to the toolbar
+        filter: dictionary
+            each key will be the search message for the user, such as "Ascii", "notebooks"
+            the value will be the search engine, such as "*.txt" or "*.ipynb"
+        stay_alive: bool (False by default)
+            if True, the fileselector won't disapear after selection of a file/directory
         """
         if type not in ['file', 'directory']:
             raise ValueError("type must be either file or directory")
@@ -71,6 +77,7 @@ class FileSelectorPanel:
         self.newdir_toolbar_button = newdir_toolbar_button
         self.createPanel(os.path.abspath(start_dir))
         self.next = next
+        self.stay_alive = stay_alive
         return
 
     def createPanel(self, curdir):
@@ -236,8 +243,13 @@ class FileSelectorPanel:
             self.selected = paths
         else:
             self.selected = paths[0]
-        # clean up
-        self.remove()
+
+        # clean up unless user choose not to
+        if self.stay_alive:
+            pass
+        else:
+            self.remove()
+
         # next step
         if self.next:
             self.next(self.selected)

--- a/ipywe/fileselector.py
+++ b/ipywe/fileselector.py
@@ -22,8 +22,8 @@ class FileSelectorPanel:
     select_layout = ipyw.Layout(width="99%", height="260px")
     select_multiple_layout = ipyw.Layout(
         width="99%", height="260px", display="flex", flex_flow="column")
-    button_layout = ipyw.Layout(margin="5px 40px", border='1px solid blue')
-    toolbar_button_layout = ipyw.Layout(margin="5px 10px", width="100px", border='1px solid blue')
+    button_layout = ipyw.Layout(margin="5px 40px", border='1px solid gray')
+    toolbar_button_layout = ipyw.Layout(margin="5px 10px", width="100px", border='1px solid gray')
     toolbar_box_layout=ipyw.Layout(border='1px solid lightgrey', padding='3px', margin='5px 50px 5px 5px', width='100%')
     label_layout = ipyw.Layout(width="250px")
     layout = ipyw.Layout()
@@ -145,11 +145,11 @@ class FileSelectorPanel:
 
         # ------------------------------------------------------------
         # |  (filter)                                                |
-        # |  Entries _______________________             |  Enter |  |
+        # |  Entries _______________________         | Change Dir |  |
+        # |          _______________________                         |
+        # |          _______________________                         |
+        # |          _______________________                         |
         # |          _______________________             | Select |  |
-        # |          _______________________                         |
-        # |          _______________________                         |
-        # |          _______________________                         |
         # ------------------------------------------------------------
         # left
         left_widgets = []
@@ -157,13 +157,16 @@ class FileSelectorPanel:
         left_widgets.append(self.select)
         left_vbox = ipyw.VBox(left_widgets, layout=ipyw.Layout(width="80%"))
         # right
-        # enter directory button
-        self.enterdir = ipyw.Button(description='Enter directory', layout=self.button_layout)
-        self.enterdir.on_click(self.handle_enterdir)
+        # change directory button
+        self.changedir = ipyw.Button(description='Change directory', layout=self.button_layout)
+        self.changedir.on_click(self.handle_changedir)
         # select button
-        self.ok = ipyw.Button(description='Select', layout=self.button_layout)
+        import copy
+        ok_layout = cloneLayout(self.button_layout)
+        ok_layout.margin = 'auto 40px 5px'; ok_layout.border = "1px solid blue"
+        self.ok = ipyw.Button(description='Select', layout=ok_layout)
         self.ok.on_click(self.validate)
-        right_vbox = ipyw.VBox(children=[self.enterdir, self.ok])
+        right_vbox = ipyw.VBox(children=[self.changedir, self.ok])
         select_panel = ipyw.HBox(
             children=[left_vbox , right_vbox],
             layout=ipyw.Layout(border='1px solid lightgrey', margin='5px', padding='10px')
@@ -228,7 +231,7 @@ class FileSelectorPanel:
         self.changeDir(path)
         return
 
-    def handle_enterdir(self, s):
+    def handle_changedir(self, s):
         v = self.select.value
         v = del_ftime(v)
         if self.multiple:
@@ -322,6 +325,13 @@ def recursive_op(w, single_op):
     single_op(w)
     return
 
+def cloneLayout(l):
+    c = ipyw.Layout()
+    for k,v in l.get_state().items():
+        if k.startswith('_'): continue
+        setattr(c, k, v)
+    return c
+
 def create_file_times(paths):
     """returns a list of file modify time"""
     ftimes = []
@@ -363,7 +373,7 @@ def del_ftime(file_label):
 '''def test1():
     panel = FileSelectorPanel("instruction", start_dir=".")
     print('\n'.join(panel._entries))
-    panel.handle_enterdir(".")
+    panel.handle_changedir(".")
     return
 
 

--- a/ipywe/fileselector.py
+++ b/ipywe/fileselector.py
@@ -19,9 +19,9 @@ class FileSelectorPanel:
     #If ipywidgets version 5.3 or higher is used, the "width="
     #statement should change the width of the file selector. "width="
     #doesn't appear to work in earlier versions.
-    select_layout = ipyw.Layout(width="750px", height="260px")
+    select_layout = ipyw.Layout(width="99%", height="260px")
     select_multiple_layout = ipyw.Layout(
-        width="750px", height="260px", display="flex", flex_flow="column")
+        width="99%", height="260px", display="flex", flex_flow="column")
     button_layout = ipyw.Layout(margin="5px 40px", border='1px solid blue')
     toolbar_button_layout = ipyw.Layout(margin="5px 10px", width="100px", border='1px solid blue')
     toolbar_box_layout=ipyw.Layout(border='1px solid lightgrey', padding='3px', margin='5px 50px 5px 5px', width='100%')
@@ -88,7 +88,7 @@ class FileSelectorPanel:
     def createBody(self, curdir):
         self.curdir = curdir
         self.footer.value = "Please wait..."
-        # toolbar
+        # toolbar on the top
         # "jump to"
         self.jumpto_input = jumpto_input = ipyw.Text(
             value=curdir, placeholder="", description="Location: ", layout=ipyw.Layout(width='100%'))
@@ -108,6 +108,7 @@ class FileSelectorPanel:
             toolbar = ipyw.HBox(children=[jumpto])
         # entries in this starting dir
 
+        
         if self.filters:
             self.createFilterWidget()
             entries_files = self.getFilteredEntries()
@@ -141,21 +142,32 @@ class FileSelectorPanel:
             description="Select",
             layout=self.select_layout) """
 
-        # filter
-        select_hbox_array = [self.select]
-        if self.filters:
-            select_hbox_array.append(self.filter_widget)
-        select_hbox = ipyw.HBox(select_hbox_array, layout=ipyw.Layout(width='100%'))
-
+        # ------------------------------------------------------------
+        # |  (filter)                                                |
+        # |  Entries _______________________             |  Enter |  |
+        # |          _______________________             | Select |  |
+        # |          _______________________                         |
+        # |          _______________________                         |
+        # |          _______________________                         |
+        # ------------------------------------------------------------
+        # left
+        left_widgets = []
+        if self.filters: left_widgets.append(self.filter_widget)
+        left_widgets.append(self.select)
+        left_vbox = ipyw.VBox(left_widgets, layout=ipyw.Layout(width="80%"))
+        # right
         # enter directory button
         self.enterdir = ipyw.Button(description='Enter directory', layout=self.button_layout)
         self.enterdir.on_click(self.handle_enterdir)
         # select button
         self.ok = ipyw.Button(description='Select', layout=self.button_layout)
         self.ok.on_click(self.validate)
-        buttons = ipyw.HBox(children=[self.enterdir, self.ok])
-        lower_panel = ipyw.VBox(children=[select_hbox , buttons], layout=ipyw.Layout(border='1px solid lightgrey', margin='5px', padding='10px'))
-        body = ipyw.VBox(children=[toolbar, lower_panel], layout=self.layout)
+        right_vbox = ipyw.VBox(children=[self.enterdir, self.ok])
+        select_panel = ipyw.HBox(
+            children=[left_vbox , right_vbox],
+            layout=ipyw.Layout(border='1px solid lightgrey', margin='5px', padding='10px')
+        )
+        body = ipyw.VBox(children=[toolbar, select_panel], layout=self.layout)
         self.footer.value = ""
         return body
 
@@ -165,7 +177,7 @@ class FileSelectorPanel:
         self.filter_widget = ipyw.Dropdown(
             options=self.filters,
             value=self.cur_filter,
-            layout=ipyw.Layout(align_self='flex-end', width='10%'))
+            layout=ipyw.Layout(align_self='flex-end', width='15%'))
         self.filter_widget.observe(self.handle_filter_changed, names='value')
         return
 

--- a/tests/test_file_selector.ipynb
+++ b/tests/test_file_selector.ipynb
@@ -2,28 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<style type=\"text/css\">\n",
-       ".jupyter-widgets select option {font-family: \"Lucida Console\", Monaco, monospace;}\n",
-       "div.output_subarea {padding: 0px;}\n",
-       "div.output_subarea > div {margin: 0.4em;}\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from __future__ import print_function\n",
     "import sys, os\n",
     "sys.path.insert(0, os.path.abspath('..'))\n",
     "import ipywe.fileselector\n",
@@ -39,39 +22,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bfbacb2edcb14f54a4f3b98f1d31f383",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>VBox</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
-      "text/plain": [
-       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints            |     Directory', ' test_file_selector.ipynb      |     Mon Feb 26 21:07:18 2018', ' test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'),), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.')\n",
     "fsel.show()"
@@ -79,21 +32,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'FileSelectorPanel' object has no attribute 'selected'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-3-88ffe0b40949>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfsel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mselected\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m: 'FileSelectorPanel' object has no attribute 'selected'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(fsel.selected)"
    ]
@@ -107,45 +48,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3de8fd8b23d749789578823fb3921cee",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>VBox</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
-      "text/plain": [
-       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints                                       |     Directory', ' /Users/j35/git/ipywe/tests/test_file_selector.ipynb      |     Mon Feb 26 21:07:18 2018', ' /Users/j35/git/ipywe/tests/test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'), Dropdown(layout=Layout(align_self='flex-end', width='10%'), options={'notebooks': ['*.ipynb'], 'csv': ['*.csv'], 'All': ['*.*']}, value=['*.ipynb'])), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', \n",
-    "                                           filter={'notebooks': ['*.ipynb'],'csv': ['*.csv']})\n",
+    "fsel= ipywe.fileselector.FileSelectorPanel(\n",
+    "    instruction='select file', start_dir='.', \n",
+    "    filters={'notebooks': ['*.ipynb'],'csv': ['*.csv']}, default_filter='notebooks')\n",
     "fsel.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print (fsel.selected)"
    ]
   },
   {
@@ -171,7 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print fsel.selected"
+    "print (fsel.selected)"
    ]
   },
   {
@@ -198,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print fsel.selected"
+    "print (fsel.selected)"
    ]
   },
   {
@@ -224,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print fsel.selected"
+    "print (fsel.selected)"
    ]
   },
   {
@@ -250,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print fsel.selected"
+    "print (fsel.selected)"
    ]
   },
   {
@@ -268,9 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def callback(selected):\n",
-    "    print selected\n",
-    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', next=callback)\n",
+    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', next=print)\n",
     "fsel.show()"
    ]
   },
@@ -362,43 +281,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1c1d673d706e47e4b35159111811b318",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/html": [
-       "<p>Failed to display Jupyter Widget of type <code>VBox</code>.</p>\n",
-       "<p>\n",
-       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
-       "  that the widgets JavaScript is still loading. If this message persists, it\n",
-       "  likely means that the widgets JavaScript library is either not installed or\n",
-       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
-       "  Widgets Documentation</a> for setup instructions.\n",
-       "</p>\n",
-       "<p>\n",
-       "  If you're reading this message in another frontend (for example, a static\n",
-       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
-       "  it may mean that your frontend doesn't currently support widgets.\n",
-       "</p>\n"
-      ],
-      "text/plain": [
-       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints            |     Directory', ' test_file_selector.ipynb      |     Tue Feb 27 06:59:04 2018', ' test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'),), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', stay_alive=True)\n",
+    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', stay_alive=True, next=print)\n",
     "fsel.show()"
    ]
   },
@@ -412,21 +301,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "dev-ipywe",
    "language": "python",
-   "name": "python3"
+   "name": "dev-ipywe"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/tests/test_file_selector.ipynb
+++ b/tests/test_file_selector.ipynb
@@ -2,12 +2,30 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style type=\"text/css\">\n",
+       ".jupyter-widgets select option {font-family: \"Lucida Console\", Monaco, monospace;}\n",
+       "div.output_subarea {padding: 0px;}\n",
+       "div.output_subarea > div {margin: 0.4em;}\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import sys, os\n",
-    "# sys.path.insert(0, os.path.abspath('..'))\n",
+    "sys.path.insert(0, os.path.abspath('..'))\n",
     "import ipywe.fileselector\n",
     "import ipywidgets as ipyw"
    ]
@@ -21,9 +39,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "84670696de3349d5add22710b2bfddc3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>VBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints            |     Directory', ' test_file_selector.ipynb      |     Mon Feb 26 21:01:18 2018', ' test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'),), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.')\n",
     "fsel.show()"
@@ -31,11 +79,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'FileSelectorPanel' object has no attribute 'selected'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-3-88ffe0b40949>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfsel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mselected\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m: 'FileSelectorPanel' object has no attribute 'selected'"
+     ]
+    }
+   ],
    "source": [
-    "print fsel.selected"
+    "print(fsel.selected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Single file selector with filter "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'generator' object has no attribute 'next'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-75600fe1dd7f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', \n\u001b[0;32m----> 2\u001b[0;31m                                            filter={'notebooks': ['*.ipynb'],'csv': ['*.csv']})\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mfsel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshow\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/git/ipywe/ipywe/fileselector.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, instruction, start_dir, type, next, multiple, newdir_toolbar_button, custom_layout, filter)\u001b[0m\n\u001b[1;32m     70\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmultiple\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmultiple\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     71\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnewdir_toolbar_button\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnewdir_toolbar_button\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 72\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreatePanel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mabspath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstart_dir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     73\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnext\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnext\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     74\u001b[0m         \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/git/ipywe/ipywe/fileselector.py\u001b[0m in \u001b[0;36mcreatePanel\u001b[0;34m(self, curdir)\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mipyw\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mLabel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstruction\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlayout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlabel_layout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfooter\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mipyw\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mHTML\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbody\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreateBody\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurdir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     80\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpanel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mipyw\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVBox\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mchildren\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbody\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfooter\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m         \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/git/ipywe/ipywe/fileselector.py\u001b[0m in \u001b[0;36mcreateBody\u001b[0;34m(self, curdir)\u001b[0m\n\u001b[1;32m    118\u001b[0m             \u001b[0;32mimport\u001b[0m \u001b[0mglob\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m             \u001b[0mlist_files\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mglob\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mglob\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_filter_selected\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 120\u001b[0;31m             \u001b[0mlist_dir\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwalk\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurdir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnext\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    121\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    122\u001b[0m             \u001b[0mentries_files\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlist_dir\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mlist_files\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'generator' object has no attribute 'next'"
+     ]
+    }
+   ],
+   "source": [
+    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', \n",
+    "                                           filter={'notebooks': ['*.ipynb'],'csv': ['*.csv']})\n",
+    "fsel.show()"
    ]
   },
   {
@@ -246,21 +341,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dev-ipywe",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "dev-ipywe"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/tests/test_file_selector.ipynb
+++ b/tests/test_file_selector.ipynb
@@ -45,7 +45,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "84670696de3349d5add22710b2bfddc3",
+       "model_id": "bfbacb2edcb14f54a4f3b98f1d31f383",
        "version_major": 2,
        "version_minor": 0
       },
@@ -65,7 +65,7 @@
        "</p>\n"
       ],
       "text/plain": [
-       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints            |     Directory', ' test_file_selector.ipynb      |     Mon Feb 26 21:01:18 2018', ' test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'),), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
+       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints            |     Directory', ' test_file_selector.ipynb      |     Mon Feb 26 21:07:18 2018', ' test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'),), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -113,18 +113,33 @@
    },
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'generator' object has no attribute 'next'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-4-75600fe1dd7f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', \n\u001b[0;32m----> 2\u001b[0;31m                                            filter={'notebooks': ['*.ipynb'],'csv': ['*.csv']})\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mfsel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshow\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/git/ipywe/ipywe/fileselector.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, instruction, start_dir, type, next, multiple, newdir_toolbar_button, custom_layout, filter)\u001b[0m\n\u001b[1;32m     70\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmultiple\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmultiple\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     71\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnewdir_toolbar_button\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnewdir_toolbar_button\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 72\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreatePanel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mabspath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstart_dir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     73\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnext\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnext\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     74\u001b[0m         \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/git/ipywe/ipywe/fileselector.py\u001b[0m in \u001b[0;36mcreatePanel\u001b[0;34m(self, curdir)\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mipyw\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mLabel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minstruction\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlayout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlabel_layout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfooter\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mipyw\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mHTML\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbody\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreateBody\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurdir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     80\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpanel\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mipyw\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVBox\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mchildren\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbody\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfooter\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m         \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/git/ipywe/ipywe/fileselector.py\u001b[0m in \u001b[0;36mcreateBody\u001b[0;34m(self, curdir)\u001b[0m\n\u001b[1;32m    118\u001b[0m             \u001b[0;32mimport\u001b[0m \u001b[0mglob\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m             \u001b[0mlist_files\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mglob\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mglob\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurdir\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_filter_selected\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 120\u001b[0;31m             \u001b[0mlist_dir\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwalk\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcurdir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnext\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    121\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    122\u001b[0m             \u001b[0mentries_files\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlist_dir\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mlist_files\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'generator' object has no attribute 'next'"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3de8fd8b23d749789578823fb3921cee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>VBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints                                       |     Directory', ' /Users/j35/git/ipywe/tests/test_file_selector.ipynb      |     Mon Feb 26 21:07:18 2018', ' /Users/j35/git/ipywe/tests/test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' /Users/j35/git/ipywe/tests/test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'), Dropdown(layout=Layout(align_self='flex-end', width='10%'), options={'notebooks': ['*.ipynb'], 'csv': ['*.csv'], 'All': ['*.*']}, value=['*.ipynb'])), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -329,6 +344,62 @@
     "# put everything together\n",
     "container = ipyw.VBox(children=[header, body, footer])\n",
     "display(container)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fileselector stays alive after validation of file/directory "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the selection has been done, even clicking **Select** won't close the fileselector display."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1c1d673d706e47e4b35159111811b318",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>VBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "VBox(children=(Label(value='select file', layout=Layout(width='250px')), VBox(children=(HBox(children=(HBox(children=(Text(value='/Users/j35/git/ipywe/tests', description='Location: ', layout=Layout(width='100%'), placeholder=''), Button(description='Jump', layout=Layout(border='1px solid blue', margin='5px 10px', width='100px'), style=ButtonStyle())), layout=Layout(border='1px solid lightgrey', margin='5px 50px 5px 5px', padding='3px', width='100%')),)), VBox(children=(HBox(children=(Select(description='Select', layout=Layout(height='260px', width='750px'), options=(' .', ' ..', ' .ipynb_checkpoints            |     Directory', ' test_file_selector.ipynb      |     Tue Feb 27 06:59:04 2018', ' test_helloworld.ipynb         |     Tue Feb 20 20:09:45 2018', ' test_image_display.ipynb      |     Tue Feb 20 20:09:45 2018', ' test_image_slider.ipynb       |     Tue Feb 20 20:09:45 2018', ' test_img_data_graph.ipynb     |     Tue Feb 20 20:09:45 2018', ' test_tomvizjs.ipynb           |     Tue Feb 20 20:09:45 2018', ' test_vtkjs.ipynb              |     Tue Feb 20 20:09:45 2018', ' test_wizard.ipynb             |     Tue Feb 20 20:09:45 2018'), value=' .'),), layout=Layout(width='100%')), HBox(children=(Button(description='Enter directory', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle()), Button(description='Select', layout=Layout(border='1px solid blue', margin='5px 40px'), style=ButtonStyle())))), layout=Layout(border='1px solid lightgrey', margin='5px', padding='10px')))), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', stay_alive=True)\n",
+    "fsel.show()"
    ]
   },
   {


### PR DESCRIPTION
This pull request implemented 2 new features, the **files filtering** and the **stay alive** flag.

**files filtering**
By passing a dictionary (key=message to display, value=search engine) it's possible to narrow down the list of files displayed

```
fsel= ipywe.fileselector.FileSelectorPanel(instruction='select file', start_dir='.', 
                                           filter={'notebooks': ['*.ipynb'],'csv': ['*.csv']})
fsel.show()
```
When passing a filter dictionary, the program will automatically add the 'All':['*.*'] element to the dictionary

**stay alive**
when the flag is passed, the application won't be removed once the user click **Select**
