### PR TITLE
Conda Python Versioning

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ git push --tags
 ```
 * build and upload
 ```
-conda build --py {{PYTHON_VERSION}} conda-recipes
+conda build --py {{PYTHON_VERSION}} conda-recipes (or CONDA_PY {{PYTHON_VERSION}} conda build conda-recipes)
 anaconda login
 anaconda upload /path/to/ipywe-...tar.bz2
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ git push --tags
 ```
 * build and upload
 ```
-conda build conda-recipes
+conda build --py {{PYTHON_VERSION}} conda-recipes
 anaconda login
 anaconda upload /path/to/ipywe-...tar.bz2
 ```

--- a/conda-recipes/conda_build_config.yaml
+++ b/conda-recipes/conda_build_config.yaml
@@ -1,5 +1,6 @@
 python:
   - 2.7
   - 3.5
-  - 3.6
-  - 3.7
+pin_run_as_build:
+  python:
+    max_pin: x

--- a/conda-recipes/conda_build_config.yaml
+++ b/conda-recipes/conda_build_config.yaml
@@ -2,5 +2,6 @@ python:
   - 2.7
   - 3.5
 pin_run_as_build:
-  python:
-    max_pin: x
+ python:
+   min_pin: x.x
+   max_pin: x

--- a/conda-recipes/meta.yaml
+++ b/conda-recipes/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   build:
-    - python {{ python }}#{{PY_VER}}*,>=2.7,<3.0|>=3.5,<4.0 
+    - python {{ python }} 
     - setuptools
     - jupyter
   run:
-    - python {{ python }}#{{PY_VER}}*,>=2.7,<3.0|>=3.5,<4.0 
+    - python {{ python }} 
     - ipywidgets >=6.0.0
     - traitlets >=4.3.0
     - pillow

--- a/conda-recipes/meta.yaml
+++ b/conda-recipes/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   build:
-    - python {{ python }}
+    - python {{ python }}#{{PY_VER}}*,>=2.7,<3.0|>=3.5,<4.0 
     - setuptools
     - jupyter
   run:
-    - python
+    - python {{ python }}#{{PY_VER}}*,>=2.7,<3.0|>=3.5,<4.0 
     - ipywidgets >=6.0.0
     - traitlets >=4.3.0
     - pillow

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class NPM(Command):
         if platform.system() == 'Windows':
             npmName = 'npm.cmd';
         return npmName;
-    
+
     def has_npm(self):
         npmName = self.get_npm_name();
         try:
@@ -173,6 +173,8 @@ setup_args = {
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 }
 


### PR DESCRIPTION
Updates the Conda recipe to allow building for any version of Python 3 >= 3.5. With this, no changes to the recipe would need to be made for new versions of Python 3. Essentially, this PR allows conda to build for Python >=2.7.0, < 3.0 and >=3.5.0, < 4.0. 

As is reflected in RELEASE.md, this PR requires building to now be done on a per-Python-version basis. In other words, instead of just running `conda build conda-recipes`, you'd have to run `conda build --py {{PYTHON_VERSION}} conda-recipes` or `CONDA_PY {{PYTHON_VERSION}} conda build conda-recipes` for each version of Python you want to upload for. `conda-build-all` could be used to allow a build for all Python versions to occur with one command, but I couldn't get it to work.

@yxqd, let me know if you want any of this in the [feedstock](https://github.com/conda-forge/ipywe-feedstock).