### PR TITLE
Fix mybinder build

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -22,10 +22,10 @@ dependencies:
 - jupyter_core=4.4.0=py_0
 - libpng=1.6.34=0
 - libsodium=1.0.15=1
-- libtiff=4.0.9=0
+- libtiff=4.0.9
 - markupsafe=1.0=py36_0
 - mistune=0.8.3=py_0
-- nbconvert=5.3.1=py_1
+- nbconvert=5.4.1=py36_3
 - nbformat=4.4.0=py36_0
 - ncurses=5.9=10
 - notebook=5.4.0=py36_0


### PR DESCRIPTION
This PR should fix the mybinder build, which failed to find/install a couple of conda packages:
```bash
$ repo2docker https://github.com/scikit-beam/ipywe
Picked Git content provider.

...

Step 39/46 : RUN conda env update -n root -f "binder/environment.yml" && conda clean -tipsy && conda list -n root
 ---> Running in abb152d882d7
Solving environment: ...working... failed

ResolvePackageNotFound:
  - nbconvert==5.3.1=py_1
  - libtiff==4.0.9=0

Removing intermediate container abb152d882d7
The command '/bin/sh -c conda env update -n root -f "binder/environment.yml" && conda clean -tipsy && conda list -n root' returned a non-zero code: 1 repo2docker
```

Here is a link for your convenience: https://mybinder.org/v2/gh/mrakitin/ipywe/fix-binder.

Closes #82.