### PR TITLE
Fix deprecated scipy call in imageslider widget

### DIFF
--- a/ipywe/imageslider.py
+++ b/ipywe/imageslider.py
@@ -169,8 +169,8 @@ class ImageSlider(base.DOMWidget):
         # resample if necessary
         resample_ratio = view_size/size
         if resample_ratio != 1.:
-            import scipy.misc
-            img = scipy.misc.imresize(img, resample_ratio)
+            from PIL import Image
+            img = np.array(Image.fromarray(img).resize((self.width, self.height)))
         """Allows the correct string IO module to be used
                based on the version of Python.
            Once support for Python 2.7 ends, this if-else statement


### PR DESCRIPTION
The `scipy.misc.imresize` function [was deprecated in scipy](https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.imresize.html) which causes an issue when running with newer versions of Python and scipy. This call was replaced with the PIL equivalent version in the imageslider widget.